### PR TITLE
Fix small amounts from being conflated with zero

### DIFF
--- a/BasicPanel.qml
+++ b/BasicPanel.qml
@@ -46,7 +46,7 @@ Rectangle {
     property alias balanceText : balanceText.text;
     property alias unlockedBalanceText : availableBalanceText.text;
     // repeating signal to the outside world
-    signal paymentClicked(string address, string paymentId, double amount, int mixinCount,
+    signal paymentClicked(string address, string paymentId, string amount, int mixinCount,
                           int priority)
 
     Connections {

--- a/MiddlePanel.qml
+++ b/MiddlePanel.qml
@@ -49,7 +49,7 @@ Rectangle {
     property Settings settingsView: Settings { }
 
 
-    signal paymentClicked(string address, string paymentId, double amount, int mixinCount, int priority)
+    signal paymentClicked(string address, string paymentId, string amount, int mixinCount, int priority)
     signal generatePaymentIdInvoked()
 
     // Disable transfer page if daemon isnt fully synced

--- a/pages/Transfer.qml
+++ b/pages/Transfer.qml
@@ -33,7 +33,7 @@ import "../components"
 
 Rectangle {
     id: root
-    signal paymentClicked(string address, string paymentId, double amount, int mixinCount,
+    signal paymentClicked(string address, string paymentId, string amount, int mixinCount,
                           int priority)
 
     color: "#F0EEEE"


### PR DESCRIPTION
Something like 0.000000000012 was converted to 1.2e-11
by the conversion to double, and that was rejected by
the Cryptonote parser.