### PR TITLE
Change organisation name to monero-project

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
 
     app.setApplicationName("monero-core");
     app.setOrganizationDomain("getmonero.org");
-    app.setOrganizationName("The Monero Project");
+    app.setOrganizationName("monero-project");
 
     filter *eventFilter = new filter;
     app.installEventFilter(eventFilter);


### PR DESCRIPTION
It seemed that there was agreement in discussion of #205 that the hyphenated 'monero-project' was to be preferred over camelcase or spacing.